### PR TITLE
upgrade abstractionkit to 0.3.5

### DIFF
--- a/examples/01-enable-email-sms-recovery/index.ts
+++ b/examples/01-enable-email-sms-recovery/index.ts
@@ -78,26 +78,38 @@ async function main() {
     // Deploy Safe with the Social Recovery Module enabled
     // Using the 3-minute grace period module for testing; change to After3Days / After7Days / After14Days for production
     const srm = new SocialRecoveryModule(SocialRecoveryModuleGracePeriodSelector.After3Minutes);
-    const enableModuleTx = srm.createEnableModuleMetaTransaction(smartAccount.accountAddress);
     const paymaster = new CandidePaymaster(paymasterUrl);
 
-    let userOperation = await smartAccount.createUserOperation([enableModuleTx], nodeUrl, bundlerUrl);
-    const [paymasterUserOperation, _sponsorMetadata] = await paymaster.createSponsorPaymasterUserOperation(
-        userOperation, bundlerUrl, sponsorshipPolicyId
-    );
-    userOperation = paymasterUserOperation;
-    userOperation.signature = smartAccount.signUserOperation(userOperation, [ownerPrivateKey], chainId);
+    // Skip the enableModule meta-transaction if the Safe is already deployed and the module is already enabled
+    // (e.g. when re-running this example with a persisted OWNER_PRIVATE_KEY)
+    const safeIsDeployed = await SafeAccountV0_3_0.isDeployed(smartAccount.accountAddress, nodeUrl);
+    const moduleAlreadyEnabled = safeIsDeployed
+        ? await smartAccount.isModuleEnabled(nodeUrl, srm.moduleAddress)
+        : false;
 
-    console.log("Deploying Safe...");
-    const deployResponse = await smartAccount.sendUserOperation(userOperation, bundlerUrl);
-    const deployResult = await deployResponse.included();
+    if (moduleAlreadyEnabled) {
+        console.log(`Social Recovery Module already enabled (${srm.moduleAddress}) — skipping deploy step\n`);
+    } else {
+        const enableModuleTx = srm.createEnableModuleMetaTransaction(smartAccount.accountAddress);
 
-    if (!deployResult.success) {
-        console.log("Safe deployment failed");
-        rl.close();
-        return;
+        let userOperation = await smartAccount.createUserOperation([enableModuleTx], nodeUrl, bundlerUrl);
+        const sponsoredDeploy = await paymaster.createSponsorPaymasterUserOperation(
+            smartAccount, userOperation, bundlerUrl, sponsorshipPolicyId
+        );
+        userOperation = sponsoredDeploy.userOperation;
+        userOperation.signature = smartAccount.signUserOperation(userOperation, [ownerPrivateKey], chainId);
+
+        console.log(safeIsDeployed ? "Enabling Social Recovery Module..." : "Deploying Safe...");
+        const deployResponse = await smartAccount.sendUserOperation(userOperation, bundlerUrl);
+        const deployResult = await deployResponse.included();
+
+        if (!deployResult || !deployResult.success) {
+            console.log("Safe deployment / module enablement failed");
+            rl.close();
+            return;
+        }
+        console.log(`Done. tx: ${deployResult.receipt.transactionHash}\n`);
     }
-    console.log(`Safe deployed. tx: ${deployResult.receipt.transactionHash}\n`);
 
     const custodialGuardianService = new RecoveryByCustodialGuardian(serviceUrl, chainId);
 
@@ -233,19 +245,19 @@ async function main() {
         1n // threshold 1 — only Candide Guardian is required to authorise recovery
     );
 
-    userOperation = await smartAccount.createUserOperation([addGuardianTx], nodeUrl, bundlerUrl);
+    let addGuardianUserOp = await smartAccount.createUserOperation([addGuardianTx], nodeUrl, bundlerUrl);
 
-    const [paymasterUserOperation2, _sponsorMetadata2] = await paymaster.createSponsorPaymasterUserOperation(
-        userOperation, bundlerUrl, sponsorshipPolicyId
+    const sponsoredAddGuardian = await paymaster.createSponsorPaymasterUserOperation(
+        smartAccount, addGuardianUserOp, bundlerUrl, sponsorshipPolicyId
     );
-    userOperation = paymasterUserOperation2;
-    userOperation.signature = smartAccount.signUserOperation(userOperation, [ownerPrivateKey], chainId);
+    addGuardianUserOp = sponsoredAddGuardian.userOperation;
+    addGuardianUserOp.signature = smartAccount.signUserOperation(addGuardianUserOp, [ownerPrivateKey], chainId);
 
     console.log("\nAdding Candide Guardian on-chain...");
-    const addGuardianResponse = await smartAccount.sendUserOperation(userOperation, bundlerUrl);
+    const addGuardianResponse = await smartAccount.sendUserOperation(addGuardianUserOp, bundlerUrl);
     const addGuardianResult = await addGuardianResponse.included();
 
-    if (!addGuardianResult.success) {
+    if (!addGuardianResult || !addGuardianResult.success) {
         console.log("Failed to add Candide Guardian");
         rl.close();
         return;

--- a/examples/01-enable-email-sms-recovery/index.ts
+++ b/examples/01-enable-email-sms-recovery/index.ts
@@ -240,29 +240,37 @@ async function main() {
         return;
     }
 
-    const addGuardianTx = srm.createAddGuardianWithThresholdMetaTransaction(
-        candideGuardianAddress,
-        1n // threshold 1 — only Candide Guardian is required to authorise recovery
+    const guardianAlreadyAdded = await srm.isGuardian(
+        nodeUrl, smartAccount.accountAddress, candideGuardianAddress
     );
 
-    let addGuardianUserOp = await smartAccount.createUserOperation([addGuardianTx], nodeUrl, bundlerUrl);
+    if (guardianAlreadyAdded) {
+        console.log(`\nCandide Guardian (${candideGuardianAddress}) already added on-chain — skipping`);
+    } else {
+        const addGuardianTx = srm.createAddGuardianWithThresholdMetaTransaction(
+            candideGuardianAddress,
+            1n // threshold 1 — only Candide Guardian is required to authorise recovery
+        );
 
-    const sponsoredAddGuardian = await paymaster.createSponsorPaymasterUserOperation(
-        smartAccount, addGuardianUserOp, bundlerUrl, sponsorshipPolicyId
-    );
-    addGuardianUserOp = sponsoredAddGuardian.userOperation;
-    addGuardianUserOp.signature = smartAccount.signUserOperation(addGuardianUserOp, [ownerPrivateKey], chainId);
+        let addGuardianUserOp = await smartAccount.createUserOperation([addGuardianTx], nodeUrl, bundlerUrl);
 
-    console.log("\nAdding Candide Guardian on-chain...");
-    const addGuardianResponse = await smartAccount.sendUserOperation(addGuardianUserOp, bundlerUrl);
-    const addGuardianResult = await addGuardianResponse.included();
+        const sponsoredAddGuardian = await paymaster.createSponsorPaymasterUserOperation(
+            smartAccount, addGuardianUserOp, bundlerUrl, sponsorshipPolicyId
+        );
+        addGuardianUserOp = sponsoredAddGuardian.userOperation;
+        addGuardianUserOp.signature = smartAccount.signUserOperation(addGuardianUserOp, [ownerPrivateKey], chainId);
 
-    if (!addGuardianResult || !addGuardianResult.success) {
-        console.log("Failed to add Candide Guardian");
-        rl.close();
-        return;
+        console.log("\nAdding Candide Guardian on-chain...");
+        const addGuardianResponse = await smartAccount.sendUserOperation(addGuardianUserOp, bundlerUrl);
+        const addGuardianResult = await addGuardianResponse.included();
+
+        if (!addGuardianResult || !addGuardianResult.success) {
+            console.log("Failed to add Candide Guardian");
+            rl.close();
+            return;
+        }
+        console.log(`Guardian added. tx: ${addGuardianResult.receipt.transactionHash}`);
     }
-    console.log(`Guardian added. tx: ${addGuardianResult.receipt.transactionHash}`);
 
     // Verify setup with getRegistrations()
     const registrationsSiweMessage = custodialGuardianService.getRegistrationsSiweStatementToSign(

--- a/examples/package.json
+++ b/examples/package.json
@@ -14,7 +14,7 @@
     "clean": "rimraf dist"
   },
   "dependencies": {
-    "abstractionkit": "^0.2.30",
+    "abstractionkit": "^0.3.5",
     "dotenv": "^16.4.5",
     "safe-recovery-service-sdk": "0.0.4",
     "viem": "^2.33.2"

--- a/examples/yarn.lock
+++ b/examples/yarn.lock
@@ -192,6 +192,13 @@ abstractionkit@^0.2.30:
     ethers "^6.13.2"
     isomorphic-unfetch "^3.1.0"
 
+abstractionkit@^0.3.5:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/abstractionkit/-/abstractionkit-0.3.5.tgz#60b50782ad55e99537e5227e21a80e71dc27ab06"
+  integrity sha512-Hjk8uYIxJx3/AsMn1BwEVXC4WBbVWen/tzVmAtfrWD2OGaJ5wDKV/X1Pgd5I4wGdRjyYjSBL9FBPOYeH2F38Iw==
+  dependencies:
+    ethers "^6.13.2"
+
 acorn-walk@^8.1.1:
   version "8.3.4"
   resolved "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"tag": "latest"
 	},
 	"dependencies": {
-		"abstractionkit": "^0.2.30",
+		"abstractionkit": "^0.3.5",
 		"isomorphic-unfetch": "^4.0.2",
 		"siwe": "^3.0.0"
 	},
@@ -49,5 +49,6 @@
 		"ts-jest": "^29.4.0",
 		"typescript": "^5.1.6",
 		"viem": "^2.33.2"
-	}
+	},
+	"packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/test/alerts.test.ts
+++ b/test/alerts.test.ts
@@ -87,7 +87,10 @@ beforeAll(async() => {
     )
 
     console.log("Useroperation sent. Waiting to be included ......")
-    let userOperationReceiptResult = await sendUserOperationResponse.included()
+    const userOperationReceiptResult = await sendUserOperationResponse.included()
+    if (!userOperationReceiptResult || !userOperationReceiptResult.success) {
+        throw new Error("Setup UserOperation was not included on-chain")
+    }
 
     console.log("Useroperation receipt received.")
 });

--- a/test/alerts.test.ts
+++ b/test/alerts.test.ts
@@ -15,7 +15,6 @@ import {
 import { Alerts } from "../src/alerts"
 
 import { hashMessage, TypedDataDomain } from 'viem';
-import { SafeAccount } from 'abstractionkit/dist/account/Safe/SafeAccount';
 
 require('dotenv').config()
 
@@ -73,8 +72,8 @@ beforeAll(async() => {
 
     const paymaster = new CandidePaymaster(paymasterUrl)
 
-    let [paymasterUserOperation, _sponsorMetadata] = await paymaster.createSponsorPaymasterUserOperation(
-        userOperation, bundlerUrl)
+    let { userOperation: paymasterUserOperation } = await paymaster.createSponsorPaymasterUserOperation(
+        smartAccount, userOperation, bundlerUrl)
     userOperation = paymasterUserOperation;
 
     userOperation.signature = smartAccount.signUserOperation(

--- a/test/recoveryByCustodialGuardian.test.ts
+++ b/test/recoveryByCustodialGuardian.test.ts
@@ -60,8 +60,8 @@ beforeAll(async() => {
 
     const paymaster = new CandidePaymaster(paymasterUrl)
 
-    let [paymasterUserOperation, _sponsorMetadata] = await paymaster.createSponsorPaymasterUserOperation(
-        userOperation, bundlerUrl)
+    let { userOperation: paymasterUserOperation } = await paymaster.createSponsorPaymasterUserOperation(
+        smartAccount, userOperation, bundlerUrl)
     userOperation = paymasterUserOperation;
 
     userOperation.signature = smartAccount.signUserOperation(
@@ -506,8 +506,8 @@ describe('RecoveryByCustodialGuardian', () => {
 
             const paymaster = new CandidePaymaster(paymasterUrl)
 
-            let [paymasterUserOperation, _sponsorMetadata] = await paymaster.createSponsorPaymasterUserOperation(
-                userOperation, bundlerUrl)
+            let { userOperation: paymasterUserOperation } = await paymaster.createSponsorPaymasterUserOperation(
+                smartAccount, userOperation, bundlerUrl)
             userOperation = paymasterUserOperation;
 
             userOperation.signature = smartAccount.signUserOperation(

--- a/test/recoveryByCustodialGuardian.test.ts
+++ b/test/recoveryByCustodialGuardian.test.ts
@@ -75,7 +75,10 @@ beforeAll(async() => {
     )
 
     console.log("Useroperation sent. Waiting to be included ......")
-    let userOperationReceiptResult = await sendUserOperationResponse.included()
+    const userOperationReceiptResult = await sendUserOperationResponse.included()
+    if (!userOperationReceiptResult || !userOperationReceiptResult.success) {
+        throw new Error("Setup UserOperation was not included on-chain")
+    }
 
     console.log("Useroperation receipt received.")
 });
@@ -521,7 +524,10 @@ describe('RecoveryByCustodialGuardian', () => {
             )
 
             console.log("Useroperation sent. Waiting to be included ......")
-            let userOperationReceiptResult = await sendUserOperationResponse.included()
+            const userOperationReceiptResult = await sendUserOperationResponse.included()
+            if (!userOperationReceiptResult || !userOperationReceiptResult.success) {
+                throw new Error("Setup UserOperation was not included on-chain")
+            }
 
             console.log("Useroperation receipt received.")
 

--- a/test/recoveryByGuardian.test.ts
+++ b/test/recoveryByGuardian.test.ts
@@ -68,8 +68,8 @@ beforeAll(async() => {
 
     const paymaster = new CandidePaymaster(paymasterUrl)
 
-    let [paymasterUserOperation, _sponsorMetadata] = await paymaster.createSponsorPaymasterUserOperation(
-        userOperation, bundlerUrl)
+    let { userOperation: paymasterUserOperation } = await paymaster.createSponsorPaymasterUserOperation(
+        smartAccount, userOperation, bundlerUrl)
     userOperation = paymasterUserOperation;
 
     userOperation.signature = smartAccount.signUserOperation(

--- a/test/recoveryByGuardian.test.ts
+++ b/test/recoveryByGuardian.test.ts
@@ -83,7 +83,10 @@ beforeAll(async() => {
     )
 
     console.log("Useroperation sent. Waiting to be included ......")
-    let userOperationReceiptResult = await sendUserOperationResponse.included()
+    const userOperationReceiptResult = await sendUserOperationResponse.included()
+    if (!userOperationReceiptResult || !userOperationReceiptResult.success) {
+        throw new Error("Setup UserOperation was not included on-chain")
+    }
 
     console.log("Useroperation receipt received.")
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1747,13 +1747,12 @@ abitype@1.0.8, abitype@^1.0.8:
   resolved "https://registry.yarnpkg.com/abitype/-/abitype-1.0.8.tgz#3554f28b2e9d6e9f35eb59878193eabd1b9f46ba"
   integrity sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg==
 
-abstractionkit@^0.2.30:
-  version "0.2.30"
-  resolved "https://registry.yarnpkg.com/abstractionkit/-/abstractionkit-0.2.30.tgz#fceed0e5d82af944233a5c3e53bddeac1ca13396"
-  integrity sha512-TSitgkJa1KS9+Chdn5pnhxUIFyTvhsp5xVdw0kjFhIKSm3i/XjlDVeyzv6kAQSht3akthG3gVOAnUkOzXyFQlA==
+abstractionkit@^0.3.5:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/abstractionkit/-/abstractionkit-0.3.5.tgz#60b50782ad55e99537e5227e21a80e71dc27ab06"
+  integrity sha512-Hjk8uYIxJx3/AsMn1BwEVXC4WBbVWen/tzVmAtfrWD2OGaJ5wDKV/X1Pgd5I4wGdRjyYjSBL9FBPOYeH2F38Iw==
   dependencies:
     ethers "^6.13.2"
-    isomorphic-unfetch "^3.1.0"
 
 acorn@^8.14.0:
   version "8.15.0"
@@ -3384,14 +3383,6 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
 
-isomorphic-unfetch@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz#87341d5f4f7b63843d468438128cb087b7c3e98f"
-  integrity sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==
-  dependencies:
-    node-fetch "^2.6.1"
-    unfetch "^4.2.0"
-
 isomorphic-unfetch@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/isomorphic-unfetch/-/isomorphic-unfetch-4.0.2.tgz#5fc04eeb1053b7b702278e2cf7a3f246cb3a9214"
@@ -4138,13 +4129,6 @@ node-domexception@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
   integrity sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==
-
-node-fetch@^2.6.1:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
-  integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
-  dependencies:
-    whatwg-url "^5.0.0"
 
 node-fetch@^3.2.0:
   version "3.3.2"
@@ -5391,11 +5375,6 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
-tr46@~0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
-  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
-
 ts-jest@^29.4.0:
   version "29.4.0"
   resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-29.4.0.tgz#bef0ee98d94c83670af7462a1617bf2367a83740"
@@ -5511,11 +5490,6 @@ undici-types@~7.8.0:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.8.0.tgz#de00b85b710c54122e44fbfd911f8d70174cd294"
   integrity sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==
 
-unfetch@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/unfetch/-/unfetch-4.2.0.tgz#7e21b0ef7d363d8d9af0fb929a5555f6ef97a3be"
-  integrity sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==
-
 unfetch@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/unfetch/-/unfetch-5.0.0.tgz#8a5b6e5779ebe4dde0049f7d7a81d4a1af99d142"
@@ -5623,19 +5597,6 @@ web-streams-polyfill@^3.0.3:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz#2073b91a2fdb1fbfbd401e7de0ac9f8214cecb4b"
   integrity sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==
-
-webidl-conversions@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
-  integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
-
-whatwg-url@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
-  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
-  dependencies:
-    tr46 "~0.0.3"
-    webidl-conversions "^3.0.0"
 
 which-boxed-primitive@^1.1.0, which-boxed-primitive@^1.1.1:
   version "1.1.1"


### PR DESCRIPTION
## Summary

Bumps `abstractionkit` from `^0.2.30` to `^0.3.5` in both the SDK and `examples/`, and adapts call sites for the 0.3.x breaking changes.

### Breaking changes adapted

- **`CandidePaymaster.createSponsorPaymasterUserOperation`** — now takes `smartAccount` as its first argument and returns `{ userOperation, sponsorMetadata }` instead of `[userOperation, sponsorMetadata]`. Fixed in `examples/01-enable-email-sms-recovery/index.ts` (two call sites) and `test/alerts.test.ts`, `test/recoveryByGuardian.test.ts`, `test/recoveryByCustodialGuardian.test.ts` (four call sites total).
- **`SendUseroperationResponse.included()`** — return type is now `Result | null`. Added null guards around `deployResult` and `addGuardianResult` in example 01.
- **Removed dist deep-import** — `abstractionkit/dist/account/Safe/SafeAccount` no longer resolves after the `microbundle → tsdown` rebuild in 0.3.0. Removed an unused `SafeAccount` import in `test/alerts.test.ts`.

Other 0.3.x breaks (the renamed `Experimental*` classes, `signUserOperationWithSigner`, ERC-7677 paymaster shape) don't affect this codebase — none of those symbols are used.

### Idempotency improvement

Example 01 now checks `SafeAccountV0_3_0.isDeployed` + `smartAccount.isModuleEnabled(srm.moduleAddress)` before building the deploy/enable-module userOperation. Re-running with a persisted `OWNER_PRIVATE_KEY` against an already-configured Safe now skips that step instead of failing.

## Test plan

- [x] `yarn build` — clean
- [x] `tsc --noEmit` on all three example entry points — clean
- [ ] `yarn test` — TypeScript compiles, but the integration tests still need a real `.env` with `CHAIN_ID` / `BUNDLER_URL` / `NODE_URL` to actually run (pre-existing requirement)
- [x] `yarn dev:enable-email-sms-recovery` against Optimism mainnet — deploys Safe, enables module, registers email channel, adds Candide Guardian — all OK end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Safeguards added to skip redundant deployment/guardian steps and to fail when on-chain guardian or setup operations are not successfully included.

* **Tests**
  * Tests updated to validate paymaster-sponsored operations and to explicitly check on-chain inclusion results before proceeding.

* **Chores**
  * Bumped abstractionkit dependency to v0.3.5 and added package manager metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->