### PR TITLE
upgrade abstractionkit to 0.3.7

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -14,7 +14,7 @@
     "clean": "rimraf dist"
   },
   "dependencies": {
-    "abstractionkit": "^0.3.5",
+    "abstractionkit": "^0.3.7",
     "dotenv": "^16.4.5",
     "safe-recovery-service-sdk": "0.0.4",
     "viem": "^2.33.2"

--- a/examples/yarn.lock
+++ b/examples/yarn.lock
@@ -192,10 +192,10 @@ abstractionkit@^0.2.30:
     ethers "^6.13.2"
     isomorphic-unfetch "^3.1.0"
 
-abstractionkit@^0.3.5:
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/abstractionkit/-/abstractionkit-0.3.5.tgz#60b50782ad55e99537e5227e21a80e71dc27ab06"
-  integrity sha512-Hjk8uYIxJx3/AsMn1BwEVXC4WBbVWen/tzVmAtfrWD2OGaJ5wDKV/X1Pgd5I4wGdRjyYjSBL9FBPOYeH2F38Iw==
+abstractionkit@^0.3.7:
+  version "0.3.7"
+  resolved "https://registry.yarnpkg.com/abstractionkit/-/abstractionkit-0.3.7.tgz#9641955ca726cc1887d397fb70d72b691e966035"
+  integrity sha512-ye2AY5e2qMJGLWsC1CE00hF+DlhZqwOqAuYMxWCfI5ya+mkrVNHmQf6ZIeKCX/CLNRV/3kLwVemKMGksjjkm3g==
   dependencies:
     ethers "^6.13.2"
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"tag": "latest"
 	},
 	"dependencies": {
-		"abstractionkit": "^0.3.5",
+		"abstractionkit": "^0.3.7",
 		"ethers": "^6.13.2",
 		"siwe": "^3.0.0"
 	},

--- a/yarn.lock
+++ b/yarn.lock
@@ -1740,10 +1740,10 @@ abitype@1.0.8, abitype@^1.0.8:
   resolved "https://registry.yarnpkg.com/abitype/-/abitype-1.0.8.tgz#3554f28b2e9d6e9f35eb59878193eabd1b9f46ba"
   integrity sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg==
 
-abstractionkit@^0.3.5:
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/abstractionkit/-/abstractionkit-0.3.5.tgz#60b50782ad55e99537e5227e21a80e71dc27ab06"
-  integrity sha512-Hjk8uYIxJx3/AsMn1BwEVXC4WBbVWen/tzVmAtfrWD2OGaJ5wDKV/X1Pgd5I4wGdRjyYjSBL9FBPOYeH2F38Iw==
+abstractionkit@^0.3.7:
+  version "0.3.7"
+  resolved "https://registry.yarnpkg.com/abstractionkit/-/abstractionkit-0.3.7.tgz#9641955ca726cc1887d397fb70d72b691e966035"
+  integrity sha512-ye2AY5e2qMJGLWsC1CE00hF+DlhZqwOqAuYMxWCfI5ya+mkrVNHmQf6ZIeKCX/CLNRV/3kLwVemKMGksjjkm3g==
   dependencies:
     ethers "^6.13.2"
 


### PR DESCRIPTION
## Summary
- Bump `abstractionkit` from `^0.3.5` to `^0.3.7` (latest) in root and `examples/`
- Update both `yarn.lock` files accordingly

## Test plan
- [x] `yarn build` passes
- [x] abstractionkit exports resolve correctly under Jest
- Note: `yarn test` requires live service/bundler/RPC URLs (integration tests); the `BigInt(process.env.CHAIN_ID)` failure is a pre-existing env issue unrelated to this upgrade and also occurs on 0.3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated abstractionkit dependency to version 0.3.7 across the project and examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/candidelabs/safe-recovery-service-sdk/pull/7)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->