### PR TITLE
Remove siwe runtime dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 		"name": "Candidelabs",
 		"url": "https://candide.dev"
 	},
-	"version": "0.0.04",
+	"version": "0.0.4",
 	"description": "Safe Recovery Service SDK by Candidelabs",
 	"main": "dist/index.js",
 	"module": "dist/index.m.js",
@@ -36,8 +36,7 @@
 	},
 	"dependencies": {
 		"abstractionkit": "^0.3.7",
-		"ethers": "^6.13.2",
-		"siwe": "^3.0.0"
+		"ethers": "^6.13.2"
 	},
 	"devDependencies": {
 		"@types/jest": "^30.0.0",
@@ -45,6 +44,7 @@
 		"jest": "^30.0.5",
 		"microbundle": "^0.15.1",
 		"rimraf": "^5.0.10",
+		"siwe": "^3.0.0",
 		"ts-jest": "^29.4.0",
 		"typescript": "^5.1.6",
 		"viem": "^2.33.2"

--- a/src/alerts.ts
+++ b/src/alerts.ts
@@ -1,5 +1,6 @@
 import { SafeRecoveryServiceSdkError, ensureError } from "./errors";
-import { generateSIWEMessage, sendHttpRequest } from "./utils";
+import { sendHttpRequest } from "./utils";
+import { generateSIWEMessage } from "./siwe";
 
 /**
  * A subscription record for Social Recovery Module alerts.

--- a/src/recoveryByCustodialGuardian.ts
+++ b/src/recoveryByCustodialGuardian.ts
@@ -1,4 +1,5 @@
-import { generateSIWEMessage, getNetworkConfig, sendHttpRequest } from "./utils";
+import { getNetworkConfig, sendHttpRequest } from "./utils";
+import { generateSIWEMessage } from "./siwe";
 import { SafeRecoveryServiceSdkError, ensureError } from "./errors";
 import { RecoveryByGuardianRequest, RecoveryByGuardian } from "./recoveryByGuardian";
 

--- a/src/safeRecoveryServiceSdk.ts
+++ b/src/safeRecoveryServiceSdk.ts
@@ -1,5 +1,5 @@
 export * from "./recoveryByCustodialGuardian";
 export * from "./recoveryByGuardian";
 export * from "./alerts";
-export { generateSIWEMessage } from "./utils";
+export { generateSIWEMessage } from "./siwe";
 export { SafeRecoveryServiceSdkError  } from "./errors";

--- a/src/siwe.ts
+++ b/src/siwe.ts
@@ -1,0 +1,55 @@
+import { getAddress } from "ethers";
+import { ensureError, SafeRecoveryServiceSdkError } from "./errors";
+
+const NONCE_ALPHABET =
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+const NONCE_LENGTH = 17;
+
+function generateNonce(): string {
+  const out: string[] = [];
+  const buf = new Uint8Array(1);
+  // Rejection sampling to avoid modulo bias (256 % 62 != 0).
+  const limit = 256 - (256 % NONCE_ALPHABET.length);
+  while (out.length < NONCE_LENGTH) {
+    crypto.getRandomValues(buf);
+    if (buf[0] < limit) {
+      out.push(NONCE_ALPHABET[buf[0] % NONCE_ALPHABET.length]);
+    }
+  }
+  return out.join("");
+}
+
+export function generateSIWEMessage(
+  accountAddress: string,
+  statement: string,
+  chainId: bigint,
+  siweDomain: string,
+  siweUri: string,
+): string {
+  try {
+    const address = getAddress(accountAddress);
+    const issuedAt = new Date().toISOString();
+    const nonce = generateNonce();
+    return (
+      `${siweDomain} wants you to sign in with your Ethereum account:\n` +
+      `${address}\n` +
+      `\n` +
+      `${statement}\n` +
+      `\n` +
+      `URI: ${siweUri}\n` +
+      `Version: 1\n` +
+      `Chain ID: ${Number(chainId)}\n` +
+      `Nonce: ${nonce}\n` +
+      `Issued At: ${issuedAt}`
+    );
+  } catch (err) {
+    const error = ensureError(err);
+    throw new SafeRecoveryServiceSdkError("SIWE_ERROR", error.message, {
+      cause: error,
+      context: {
+        accountAddress,
+        statement,
+      },
+    });
+  }
+}

--- a/src/siwe.ts
+++ b/src/siwe.ts
@@ -5,6 +5,30 @@ const NONCE_ALPHABET =
   "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
 const NONCE_LENGTH = 17;
 
+// Control chars (C0 + DEL) break the single-line EIP-4361 grammar. The old
+// `new SiweMessage(...)` path round-trip-parsed and threw on these; preserve
+// that so invalid input fails fast as SIWE_ERROR rather than producing a
+// message the backend parser rejects later.
+const CONTROL_CHARS = /[\u0000-\u001F\u007F]/;
+
+function validateSiweFields(
+  statement: string,
+  siweDomain: string,
+  siweUri: string,
+): void {
+  if (CONTROL_CHARS.test(statement)) {
+    throw new Error("invalid SIWE statement: control characters not allowed");
+  }
+  if (siweDomain === "" || /\s/.test(siweDomain) || CONTROL_CHARS.test(siweDomain)) {
+    throw new Error(`invalid SIWE domain: ${JSON.stringify(siweDomain)}`);
+  }
+  try {
+    new URL(siweUri);
+  } catch {
+    throw new Error(`invalid SIWE URI: ${JSON.stringify(siweUri)}`);
+  }
+}
+
 function generateNonce(): string {
   const out: string[] = [];
   const buf = new Uint8Array(1);
@@ -28,6 +52,7 @@ export function generateSIWEMessage(
 ): string {
   try {
     const address = getAddress(accountAddress);
+    validateSiweFields(statement, siweDomain, siweUri);
     const issuedAt = new Date().toISOString();
     const nonce = generateNonce();
     return (

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,3 @@
-import {SiweMessage, generateNonce} from "siwe";
-import {getAddress} from "ethers";
 import { ensureError, HttpErrorCodeDict, SafeRecoveryServiceSdkError } from "./errors";
 import { RecoveryByGuardianRequest } from "./recoveryByGuardian";
 import { AlertsSubscription } from "./alerts";
@@ -12,43 +10,6 @@ export enum SocialRecoveryModuleGracePeriodSelector {
 	After7Days = "0x088f6cfD8BB1dDb1BB069CCb3fc1A98927D233f2",
 	After14Days = "0x9BacD92F4687Db306D7ded5d4513a51EA05df25b",
 }
-export function generateSIWEMessage(
-    accountAddress: string,
-    statement: string,
-    chainId: bigint,
-    siweDomain: string,
-    siweUri: string
-): string {
-    try {
-        const issuedAt = new Date().toISOString();
-        const siweMessage = new SiweMessage({
-          version: "1",
-          address: getAddress(accountAddress),
-          domain: siweDomain,
-          uri: siweUri,
-          statement,
-          chainId: Number(chainId),
-          nonce: generateNonce(),
-          issuedAt
-        });
-        return siweMessage.prepareMessage();
-    } catch (err) {
-        const error = ensureError(err);
-
-        throw new SafeRecoveryServiceSdkError(
-            "SIWE_ERROR",
-            error.message,
-            {
-                cause: error,
-                context:{
-                    accountAddress,
-                    statement,
-                }
-            }
-        );
-    }
-}
-
 export type JsonRpcResult =
     NetworkConfig |
     {success: boolean, signer?: string, signature?: string} |

--- a/test/siwe.test.ts
+++ b/test/siwe.test.ts
@@ -1,0 +1,83 @@
+import { SiweMessage } from "siwe";
+import { getAddress } from "ethers";
+import { generateSIWEMessage } from "../src/siwe";
+import { SafeRecoveryServiceSdkError } from "../src/errors";
+
+const ACCOUNT = "0x388c818ca8b9251b393131c08a736a67ccb19297"; // lowercase on purpose
+const STATEMENT = "Sign in to Safe Recovery Service";
+const DOMAIN = "service://safe-recovery-service";
+const URI = "service://safe-recovery-service";
+
+describe("generateSIWEMessage", () => {
+  it("produces a string that the real SIWE parser accepts and round-trips", () => {
+    const msg = generateSIWEMessage(ACCOUNT, STATEMENT, 11155111n, DOMAIN, URI);
+    const parsed = new SiweMessage(msg); // throws if format is invalid
+
+    expect(parsed.address).toBe(getAddress(ACCOUNT));
+    expect(parsed.scheme).toBe("service");
+    expect(parsed.domain).toBe("safe-recovery-service");
+    expect(parsed.uri).toBe(URI);
+    expect(parsed.version).toBe("1");
+    expect(parsed.chainId).toBe(11155111);
+    expect(parsed.statement).toBe(STATEMENT);
+    expect(parsed.nonce).toMatch(/^[A-Za-z0-9]{17}$/);
+    expect(typeof parsed.issuedAt).toBe("string");
+    expect(Number.isNaN(Date.parse(parsed.issuedAt as string))).toBe(false);
+  });
+
+  it("emits the exact EIP-4361 layout (no trailing newline, single blank-line separators)", () => {
+    const msg = generateSIWEMessage(ACCOUNT, STATEMENT, 1n, DOMAIN, URI);
+    const lines = msg.split("\n");
+    expect(msg.endsWith("\n")).toBe(false);
+    expect(lines[0]).toBe(`${DOMAIN} wants you to sign in with your Ethereum account:`);
+    expect(lines[1]).toBe(getAddress(ACCOUNT));
+    expect(lines[2]).toBe("");
+    expect(lines[3]).toBe(STATEMENT);
+    expect(lines[4]).toBe("");
+    expect(lines[5]).toBe(`URI: ${URI}`);
+    expect(lines[6]).toBe("Version: 1");
+    expect(lines[7]).toBe("Chain ID: 1");
+    expect(lines[8]).toMatch(/^Nonce: [A-Za-z0-9]{17}$/);
+    expect(lines[9]).toMatch(/^Issued At: /);
+    expect(lines.length).toBe(10);
+  });
+
+  it("matches siwe's own prepareMessage byte-for-byte for identical inputs", () => {
+    const msg = generateSIWEMessage(ACCOUNT, STATEMENT, 1n, DOMAIN, URI);
+    const parsed = new SiweMessage(msg);
+    const reference = new SiweMessage({
+      version: "1",
+      address: getAddress(ACCOUNT),
+      domain: DOMAIN,
+      uri: URI,
+      statement: STATEMENT,
+      chainId: 1,
+      nonce: parsed.nonce,
+      issuedAt: parsed.issuedAt,
+    }).prepareMessage();
+    expect(msg).toBe(reference);
+  });
+
+  it("generates unique nonces across many calls", () => {
+    const nonces = new Set<string>();
+    for (let i = 0; i < 500; i++) {
+      const parsed = new SiweMessage(
+        generateSIWEMessage(ACCOUNT, STATEMENT, 1n, DOMAIN, URI),
+      );
+      nonces.add(parsed.nonce);
+    }
+    expect(nonces.size).toBe(500);
+  });
+
+  it("wraps invalid address in SafeRecoveryServiceSdkError SIWE_ERROR", () => {
+    expect.assertions(3);
+    try {
+      generateSIWEMessage("not-an-address", STATEMENT, 1n, DOMAIN, URI);
+    } catch (e) {
+      const err = e as SafeRecoveryServiceSdkError;
+      expect(err).toBeInstanceOf(SafeRecoveryServiceSdkError);
+      expect(err.code).toBe("SIWE_ERROR");
+      expect(err.context).toMatchObject({ accountAddress: "not-an-address", statement: STATEMENT });
+    }
+  });
+});

--- a/test/siwe.test.ts
+++ b/test/siwe.test.ts
@@ -80,4 +80,35 @@ describe("generateSIWEMessage", () => {
       expect(err.context).toMatchObject({ accountAddress: "not-an-address", statement: STATEMENT });
     }
   });
+
+  it.each([
+    ["statement with newline", "hello\nworld", DOMAIN, URI],
+    ["statement with tab", "hello\tworld", DOMAIN, URI],
+    ["empty domain", STATEMENT, "", URI],
+    ["domain with spaces", STATEMENT, "bad domain !!", URI],
+    ["non-URI uri", STATEMENT, DOMAIN, "not a uri"],
+  ])(
+    "wraps invalid SIWE field (%s) as SafeRecoveryServiceSdkError SIWE_ERROR",
+    (_label, statement, domain, uri) => {
+      expect.assertions(2);
+      try {
+        generateSIWEMessage(ACCOUNT, statement, 1n, domain, uri);
+      } catch (e) {
+        const err = e as SafeRecoveryServiceSdkError;
+        expect(err).toBeInstanceOf(SafeRecoveryServiceSdkError);
+        expect(err.code).toBe("SIWE_ERROR");
+      }
+    },
+  );
+
+  it("still accepts the SDK's default service:// domain and URI", () => {
+    const msg = generateSIWEMessage(
+      ACCOUNT,
+      STATEMENT,
+      1n,
+      "service://safe-recovery-service",
+      "service://safe-recovery-service",
+    );
+    expect(msg).toContain("service://safe-recovery-service wants you to sign in");
+  });
 });


### PR DESCRIPTION
## Summary
- Replace the `siwe` package with a dependency-free, **synchronous** EIP-4361 message builder (`src/siwe.ts`), eliminating the `siwe → @spruceid/siwe-parser → apg-js → buffer` chain from consumer bundles (fixes Vite `buffer` polyfill warning for frontend integrators).
- Public API is unchanged: `generateSIWEMessage` keeps its exact signature and stays synchronous; all 6 call sites in `alerts.ts` / `recoveryByCustodialGuardian.ts` and the public re-export are untouched behaviorally. `utils.ts` is now siwe/ethers-free.
- `siwe` moved to `devDependencies`, used only by a round-trip test that proves byte-for-byte compatibility with the real parser. Also normalizes the package version string `0.0.04 → 0.0.4`.
- Runtime deps reduced to `abstractionkit` + `ethers` only; built `dist/` contains zero `siwe`/`siwe-parser`/`apg-js` package references.

Design spec and implementation plan included under `docs/superpowers/`.

## Test plan
- [x] `yarn test test/siwe.test.ts` — 5/5 pass, including a byte-for-byte equality test vs the real `siwe@3` `prepareMessage()` and a dependency-independent EIP-4361 layout test
- [x] `yarn build` succeeds with no `buffer` polyfill warning; `dist/` bundle requires only `abstractionkit` + `ethers`
- [x] Live validation against the recovery service: examples 01–03 run end-to-end (custodial registration + recovery flow) with no `SIWE_ERROR`
- [x] Live `getActiveSubscriptions` (off-chain EOA-signed SIWE) accepted by the backend parser — confirms the hand-built EIP-4361 string is byte-compatible in production
- [ ] Reviewer: confirm no consumer relies on `siwe` being a transitive runtime dep

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.0.4
  * Moved a package to devDependencies to separate build-time vs runtime libs

* **New Features**
  * Added robust SIWE sign-in message generation with stricter validation and safer nonce generation

* **Tests**
  * Expanded test coverage for message generation, validation, and error-wrapping behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/candidelabs/safe-recovery-service-sdk/pull/8)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->